### PR TITLE
fix: use start_after instead of resume_after for change stream tokens if MongoDB version >= 4.2

### DIFF
--- a/plugins/loaders/target-jsonl--andyh1203.lock
+++ b/plugins/loaders/target-jsonl--andyh1203.lock
@@ -1,0 +1,34 @@
+{
+  "plugin_type": "loaders",
+  "name": "target-jsonl",
+  "namespace": "target_jsonl",
+  "variant": "andyh1203",
+  "label": "JSON Lines (JSONL)",
+  "docs": "https://hub.meltano.com/loaders/target-jsonl--andyh1203",
+  "repo": "https://github.com/andyh1203/target-jsonl",
+  "pip_url": "target-jsonl",
+  "description": "JSONL loader",
+  "logo_url": "https://hub.meltano.com/assets/logos/loaders/jsonl.png",
+  "settings": [
+    {
+      "name": "destination_path",
+      "kind": "string",
+      "value": "output",
+      "label": "Destination Path",
+      "description": "Sets the destination path the JSONL files are written to, relative\nto the project root.\n\nThe directory needs to exist already, it will not be created\nautomatically.\n\nTo write JSONL files to the project root, set an empty string (`\"\"`).\n"
+    },
+    {
+      "name": "do_timestamp_file",
+      "kind": "boolean",
+      "value": false,
+      "label": "Include Timestamp in File Names",
+      "description": "Specifies if the files should get timestamped.\n\nBy default, the resulting file will not have a timestamp in the file name (i.e. `exchange_rate.jsonl`).\n\nIf this option gets set to `true`, the resulting file will have a timestamp associated with it (i.e. `exchange_rate-{timestamp}.jsonl`).\n"
+    },
+    {
+      "name": "custom_name",
+      "kind": "string",
+      "label": "Custom File Name Override",
+      "description": "Specifies a custom name for the filename, instead of the stream name.\n\nThe file name will be `{custom_name}-{timestamp}.jsonl`, if `do_timestamp_file` is `true`.\nOtherwise the file name will be `{custom_name}.jsonl`.\n\nIf custom name is not provided, the stream name will be used.\n"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mongodb"
-version = "2.3.3"
+version = "2.4.0"
 description = "`tap-mongodb` is a Singer tap for MongoDB and AWS DocumentDB, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Matt Menzenski"]

--- a/tap_mongodb/connector.py
+++ b/tap_mongodb/connector.py
@@ -2,7 +2,7 @@
 
 import sys
 from logging import Logger, getLogger
-from typing import Any, Dict, List, Optional, Tuple, TypeAlias
+from typing import Any, Dict, List, Optional, Tuple
 
 from pymongo import MongoClient
 from pymongo.database import Database
@@ -17,7 +17,13 @@ else:
     from functools import cached_property
 
 
-MongoVersion: TypeAlias = Tuple[int, int]
+try:
+    from typing import TypeAlias  # pylint: disable=ungrouped-imports
+
+    MongoVersion: TypeAlias = Tuple[int, int]
+except ImportError:
+    TypeAlias = None
+    MongoVersion = Tuple[int, int]
 
 
 class MongoDBConnector:

--- a/tap_mongodb/streams.py
+++ b/tap_mongodb/streams.py
@@ -218,7 +218,13 @@ class MongoDBCollectionStream(Stream):
             change_stream_options = {"full_document": "updateLookup"}
             if bookmark is not None and bookmark != DEFAULT_START_DATE:
                 self.logger.debug(f"using bookmark: {bookmark}")
-                change_stream_options["resume_after"] = {"_data": bookmark}
+                # if on mongo version 4.2 or above, use start_after instead of resume_after, as the former will
+                # gracefully open a new change stream if the resume token's event is not present in the oplog, while
+                # the latter will error in that scenario.
+                if self._connector.version >= (4, 2):
+                    change_stream_options["start_after"] = {"_data": bookmark}
+                else:
+                    change_stream_options["resume_after"] = {"_data": bookmark}
             operation_types_allowlist: set = set(self.config.get("operation_types"))
             has_seen_a_record: bool = False
             keep_open: bool = True
@@ -245,7 +251,8 @@ class MongoDBCollectionStream(Stream):
                             f"Unable to enable change streams on collection {collection.name}"
                         ) from operation_failure
                 elif (
-                    operation_failure.code == 286
+                    self._connector.version < (4, 2)
+                    and operation_failure.code == 286
                     and "as the resume point may no longer be in the oplog." in operation_failure.details["errmsg"]
                 ):
                     self.logger.warning("Unable to resume change stream from resume token. Resetting resume token.")
@@ -265,7 +272,8 @@ class MongoDBCollectionStream(Stream):
                         record = change_stream.try_next()
                     except OperationFailure as operation_failure:
                         if (
-                            operation_failure.code == 286
+                            self._connector.version < (4, 2)
+                            and operation_failure.code == 286
                             and "as the resume point may no longer be in the oplog."
                             in operation_failure.details["errmsg"]
                         ):


### PR DESCRIPTION
This tap has had some issues in log-based replication mode and I've been trying to chase those down and make this resilient in the face of all scenarios. This PR updates the "resume change stream" handling that is used when the tap is running in log-based mode using a saved bookmark (that is, when not in "full refresh" mode).

Previously the tap was passing the saved resume token from the meltano state to the "open change stream" command in the `resume_after` field. This field is supported by all versions of MongoDB change streams (MongoDB 3.6 and above).

In MongoDB 4.2, a new `start_after` field was added to the "open change stream" command. This is preferable to `resume_after` for this tap's use cases, so this PR uses the `start_after` field if the MongoDB version is 4.2 or greater.

Why is `start_after` preferable? See the docs: https://www.mongodb.com/docs/manual/changeStreams/#startafter-for-change-streams But tl;dr: If a given resume token is not present in the oplog (which can happen if this tap has not been run in X hours, where X > oplog headroom in hours), `start_after` will gracefully open a new change stream, while `resume_after` will error.